### PR TITLE
Added quotes in config file

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -2,12 +2,12 @@ services:
     paybas.quickstyle.listener:
         class: paybas\quickstyle\event\listener
         arguments:
-            - @config
-            - @dbal.conn
-            - @request
-            - @template
-            - @user
-            - %core.root_path%
-            - %core.php_ext%
+            - '@config'
+            - '@dbal.conn'
+            - '@request'
+            - '@template'
+            - '@user'
+            - '%core.root_path%'
+            - '%core.php_ext%'
         tags:
             - { name: event.listener }


### PR DESCRIPTION
Fixed invalid YAML: The reserved indicator "@" cannot start a plain scalar

Causes error in phpbb v3.3